### PR TITLE
カラーピッカーが画面左上に表示されるバグを修正しました。

### DIFF
--- a/src/components/color-picker.tsx/color-picker.tsx
+++ b/src/components/color-picker.tsx/color-picker.tsx
@@ -21,15 +21,15 @@ export default function ColorPicker({ color, setColor }: Props) {
       className="flex items-center gap-3 border-[#e1e1e1] border-[1px] bg-[#fafafa] rounded-md w-full px-3 py-3"
     >
       <div
-        className="size-[30px] rounded-md"
+        className="w-[30px] h-[30px] rounded-md"
         style={{ backgroundColor: color }}
         aria-hidden="true"
       />
       <p>{color.toUpperCase()}</p>
       <input
         type="color"
+        className="absolute opacity-0 w-[30px] h-[30px] cursor-pointer"
         ref={colorInputRef}
-        className="hidden"
         value={color}
         onChange={(e) => setColor(e.target.value)}
       />


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
カラーピッカーが画面左上に表示されるバグを修正しました。

## スクショ
<img width="1512" alt="スクリーンショット 2024-10-16 22 27 26" src="https://github.com/user-attachments/assets/784271b1-47e7-41f1-9886-37d2c2eaa8d0">

## issue
close 

## 懸念点
